### PR TITLE
Add support for admin groups through generic OAuth

### DIFF
--- a/cps/oauth_bb.py
+++ b/cps/oauth_bb.py
@@ -407,7 +407,7 @@ if ub.oauth_support:
             user.email = generic_user_email
             
             user.role = constants.ROLE_USER | constants.ROLE_DOWNLOAD | constants.ROLE_UPLOAD | constants.ROLE_VIEWER
-            user.sidebar_view = constants.SIDEBAR_ARCHIVED | constants.SIDEBAR_LANGUAGE | constants.SIDEBAR_SERIES | constants.SIDEBAR_CATEGORY | constants.SIDEBAR_HOT | constants.SIDEBAR_RANDOM | constants.SIDEBAR_AUTHOR | constants.SIDEBAR_BEST_RATED | constants.SIDEBAR_RECENT | constants.SIDEBAR_SORTED | constants.SIDEBAR_ARCHIVED | constants.SIDEBAR_PUBLISHER
+            user.sidebar_view = constants.SIDEBAR_ARCHIVED | constants.SIDEBAR_LANGUAGE | constants.SIDEBAR_SERIES | constants.SIDEBAR_CATEGORY | constants.SIDEBAR_HOT | constants.SIDEBAR_RANDOM | constants.SIDEBAR_AUTHOR | constants.SIDEBAR_BEST_RATED | constants.SIDEBAR_RECENT | constants.SIDEBAR_SORTED | constants.SIDEBAR_PUBLISHER
 
             if generic_info.get('admin') or 'admin' in generic_info.get('groups', []):
                 user.role |= constants.ROLE_ADMIN | constants.ROLE_DELETE_BOOKS | constants.ROLE_EDIT | constants.ROLE_PASSWD | constants.ROLE_EDIT_SHELFS


### PR DESCRIPTION
Title.

This requires the `groups` OICD claim. If it is present and contains a group named `admin`, a user will gain admin privileges when registering through OIDC.
