### PR TITLE
Feat: Add Manual Installation Support Without Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Autocaliweb is a web app that offers a clean and intuitive interface for browsin
 2. [Features](#features)
 3. [Installation](#installation)
    - [Installation via Docker (recommended)](#installation-via-docker-recommended)
+   - [Manual-Installation - without Docker](#manual-installation-without-docker)
    - [After Installation](#after-installation)
    - [Deploy Requirements](#deploy-requirements)
 4. [Troubleshooting](#troubleshooting)
@@ -109,6 +110,8 @@ services:
     stop_signal: SIGINT
     stop_grace_period: 15s
 ```
+### Manual installation without Docker  
+For manual installation without docker see [Manual Installation](https://github.com/gelbphoenix/autocaliweb/wiki/Manual-Installation).  
 
 ## After Installation
 

--- a/scripts/install_autocaliweb.sh
+++ b/scripts/install_autocaliweb.sh
@@ -1,0 +1,375 @@
+#!/bin/bash
+# install_autocaliweb.sh - Run as regular user
+#
+# Copyright (C) 2025 Autocaliweb
+# First creator UsamaFoad <usamafoad@gmail.com>
+set -e
+
+echo "=== Autocaliweb Manual Installation Script ==="
+
+# Configuration
+INSTALL_DIR="/app/autocaliweb"
+CONFIG_DIR="/config"
+CALIBRE_LIB_DIR="/calibre-library"
+INGEST_DIR="/acw-book-ingest"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+ 
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if running as root
+if [[ $EUID -eq 0 ]]; then
+   print_error "This script should not be run as root for security reasons"
+   exit 1
+fi
+
+# Checking required dependencies
+check_dependencies() {
+    print_status "Checking required dependencies..."
+    
+    local missing_deps=()
+    
+    for cmd in curl git sqlite3 python3; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            missing_deps+=("$cmd")
+        fi
+    done
+    
+    if [ ${#missing_deps[@]} -ne 0 ]; then
+        print_error "Missing required dependencies: ${missing_deps[*]}"
+        print_error "Please install them before running this script"
+        exit 1
+    fi
+}
+
+# Install system dependencies
+install_system_deps() {
+    print_status "Installing system dependencies..."
+    
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends \
+        python3-dev python3-pip python3-venv \
+        imagemagick ghostscript \
+        libmagic1 libxi6 libxslt1.1 \
+        libxtst6 libxrandr2 libxkbfile1 \
+        libxcomposite1 libopengl0 libnss3 \
+        libxkbcommon0 libegl1 libxdamage1 \
+        libgl1 libglx-mesa0 xz-utils \
+        sqlite3 xdg-utils inotify-tools \
+        netcat-openbsd binutils curl wget
+}
+
+# Check directory structure
+check_directories() {
+    print_status "Checking directory structure..."
+    
+    # Check if main directories exist
+    if [ ! -d "$INSTALL_DIR" ] || [ ! -d "$CONFIG_DIR" ]; then
+        print_error "Required directories not found. Please run prep_autocaliweb.sh as root first."
+        print_error "Run: sudo ./prep_autocaliweb.sh"
+        exit 1
+    fi
+    
+    # Verify ownership
+    if [ ! -w "$INSTALL_DIR" ] || [ ! -w "$CONFIG_DIR" ]; then
+        print_error "Insufficient permissions for required directories."
+        print_error "Please ensure prep_autocaliweb.sh was run correctly."
+        exit 1
+    fi
+    
+    print_status "Directory structure verified"
+}
+
+# Download and setup Autocaliweb
+setup_autocaliweb() {
+    print_status "Setting up Autocaliweb..."
+    
+    cd "$INSTALL_DIR"
+    
+    # Clone or download Autocaliweb (assuming you have the source)
+    if [ ! -f "requirements.txt" ]; then
+        print_error "Please ensure Autocaliweb source code is in $INSTALL_DIR"
+        exit 1
+    fi
+    
+    # Create virtual environment
+    python3 -m venv venv
+    source venv/bin/activate
+    
+    # Upgrade pip and install dependencies
+    pip install -U pip wheel
+    pip install -r requirements.txt -r optional-requirements.txt
+    
+    print_status "Python dependencies installed successfully"
+}
+
+# Separate function for Calibre installation
+install_calibre() {
+    print_status "Installing Calibre..."
+    sudo mkdir -p /app/calibre
+    CALIBRE_RELEASE=$(curl -s https://api.github.com/repos/kovidgoyal/calibre/releases/latest | grep -o '"tag_name": "[^"]*' | cut -d'"' -f4)
+    CALIBRE_VERSION=${CALIBRE_RELEASE#v}
+    CALIBRE_ARCH=$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/arm64/')
+    
+    curl -o /tmp/calibre.txz -L "https://download.calibre-ebook.com/${CALIBRE_VERSION}/calibre-${CALIBRE_VERSION}-${CALIBRE_ARCH}.txz"
+    sudo tar xf /tmp/calibre.txz -C /app/calibre
+    sudo /app/calibre/calibre_postinstall
+    rm /tmp/calibre.txz
+    echo "$CALIBRE_RELEASE" > /app/CALIBRE_RELEASE
+}
+
+# Separate function for Kepubify installation
+install_kepubify() {
+    print_status "Installing Kepubify..."
+    KEPUBIFY_RELEASE=$(curl -s https://api.github.com/repos/pgaskin/kepubify/releases/latest | grep -o '"tag_name": "[^"]*' | cut -d'"' -f4)
+    ARCH=$(uname -m | sed 's/x86_64/64bit/;s/aarch64/arm64/')
+    
+    sudo curl -Lo /usr/bin/kepubify "https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-${ARCH}"
+    sudo chmod +x /usr/bin/kepubify
+    echo "$KEPUBIFY_RELEASE" > /app/KEPUBIFY_RELEASE
+}
+
+# Install external tools (with detection)
+install_external_tools() {
+    print_status "Checking for external tools..."
+    
+    # Check for existing Calibre installation
+    if command -v calibre >/dev/null 2>&1 || command -v ebook-convert >/dev/null 2>&1; then
+        print_status "Calibre already installed, skipping installation"
+        CALIBRE_PATH=$(dirname $(which ebook-convert 2>/dev/null || which calibre))
+        
+        # Create Calibre version file
+    if command -v calibre >/dev/null 2>&1; then
+        if calibre --version | head -1 | cut -d' ' -f3 | sed 's/)//' > /app/CALIBRE_RELEASE 2>/dev/null; then
+            print_status "Calibre version file created successfully"  
+        else
+            print_warning "Could not determine Calibre version, using 'Unknown'"  
+            echo "Unknown" > /app/CALIBRE_RELEASE  
+        fi  
+    else
+        echo "Unknown" > /app/CALIBRE_RELEASE  
+    fi
+
+        echo "Using existing Calibre at: $CALIBRE_PATH"
+    else
+        read -p "Calibre not found. Install Calibre? (y/n): " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            install_calibre
+        else
+            print_warning "Skipping Calibre installation. You'll need to install it manually."
+        echo "Unknown" > /app/CALIBRE_RELEASE
+        fi
+    fi
+    
+    # Check for existing Kepubify installation
+    if command -v kepubify >/dev/null 2>&1; then
+        print_status "Kepubify already installed, skipping installation"
+        KEPUBIFY_PATH=$(which kepubify)
+    kepubify --version | head -1 | cut -d' ' -f2 > /app/KEPUBIFY_RELEASE
+        echo "Using existing Kepubify at: $KEPUBIFY_PATH"
+    else
+        read -p "Kepubify not found. Install Kepubify? (y/n): " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            install_kepubify
+        else
+            print_warning "Skipping Kepubify installation. You'll need to install it manually."
+        echo "Unknown" > /app/KEPUBIFY_RELEASE
+        fi
+    fi
+}
+
+# Initialize databases with detected binary paths
+initialize_databases() {
+    print_status "Initializing databases..."
+    
+    # Detect binary paths
+    KEPUBIFY_PATH=$(which kepubify 2>/dev/null || echo "/usr/bin/kepubify")
+    EBOOK_CONVERT_PATH=$(which ebook-convert 2>/dev/null || echo "/usr/bin/ebook-convert")
+    CALIBRE_BIN_DIR=$(dirname "$EBOOK_CONVERT_PATH")
+    
+    # Copy template app.db if it doesn't exist
+    if [ ! -f "$CONFIG_DIR/app.db" ]; then
+        if [ -f "$INSTALL_DIR/library/app.db" ]; then
+            cp "$INSTALL_DIR/library/app.db" "$CONFIG_DIR/app.db"
+            print_status "Template app.db copied to $CONFIG_DIR"
+        else
+            print_warning "Template app.db not found, will be created on first run"
+        fi
+    fi
+    
+    # Set correct binary paths in database
+    if [ -f "$CONFIG_DIR/app.db" ]; then
+        sqlite3 "$CONFIG_DIR/app.db" <<EOS
+UPDATE settings SET 
+    config_kepubifypath='$KEPUBIFY_PATH',
+    config_converterpath='$EBOOK_CONVERT_PATH',
+    config_binariesdir='$CALIBRE_BIN_DIR'
+WHERE 1=1;
+EOS
+        print_status "Binary paths configured in database: Kepubify=$KEPUBIFY_PATH, ebook-convert=$EBOOK_CONVERT_PATH"
+    fi
+}
+
+# Create systemd service
+create_systemd_service() {
+    print_status "Creating systemd service..."
+    
+    sudo tee /etc/systemd/system/autocaliweb.service > /dev/null <<EOF
+[Unit]
+Description=Autocaliweb
+After=network.target
+
+[Service]
+Type=simple
+User=$USER
+Group=$USER
+WorkingDirectory=$INSTALL_DIR
+Environment=PATH=$INSTALL_DIR/venv/bin:/usr/bin:/bin
+Environment=PYTHONPATH=$INSTALL_DIR/scripts:$INSTALL_DIR
+Environment=CALIBRE_DBPATH=$CONFIG_DIR
+ExecStart=$INSTALL_DIR/venv/bin/python $INSTALL_DIR/cps.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable autocaliweb
+    
+    print_status "Systemd service created and enabled"
+}
+
+# Set up configuration files
+setup_configuration() {
+    print_status "Setting up configuration files..."
+    
+    # Update dirs.json with correct paths
+    cat > "$INSTALL_DIR/dirs.json" <<EOF
+{
+  "ingest_folder": "$INGEST_DIR",
+  "calibre_library_dir": "$CALIBRE_LIB_DIR",
+  "tmp_conversion_dir": "$CONFIG_DIR/.acw_conversion_tmp"
+}
+EOF
+    
+    # Create metadata directories
+    mkdir -p "$INSTALL_DIR"/{metadata_change_logs,metadata_temp}
+    # Create Autocaliweb version file
+    if git rev-parse --git-dir > /dev/null 2>&1; then  
+        echo "manual-v$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo '1.0.0')" > /app/ACW_RELEASE  
+    else  
+        echo "manual-v1.0.0" > /app/ACW_RELEASE  
+    fi
+    
+    print_status "Configuration files updated"
+}
+
+# Retrieve main.js before Commit 1b3c75c  
+print_status "Retrieving main.js file..."  
+retrieve_old_main_js() {  
+  if curl https://raw.githubusercontent.com/gelbphoenix/autocaliweb/dfd3a361af23bb5e7f1613f88cf3b19e0aee7c27/cps/static/js/main.js -o /app/autocaliweb/cps/static/js/main.js; then  
+    print_status "main.js file retrieved successfully."  
+  else  
+    print_error "Failed to retrieve main.js file."  
+    exit 1 # Exit if the file retrieval fails  
+  fi  
+}
+
+# Set permissions
+set_permissions() {
+    print_status "Setting permissions..."
+    
+    # Set ownership for all directories
+    sudo chown -R $USER:$USER "$INSTALL_DIR" "$CONFIG_DIR" "$CALIBRE_LIB_DIR" "$INGEST_DIR" /app
+    
+    # Set executable permissions for scripts
+    find "$INSTALL_DIR/scripts" -name "*.py" -exec chmod +x {} \;
+    chmod +x "$INSTALL_DIR/cps.py"
+    
+    print_status "Permissions set successfully"
+}
+
+# Create startup script
+create_startup_script() {
+    print_status "Creating startup script..."
+    
+    cat > "$INSTALL_DIR/start_autocaliweb.sh" <<EOF
+#!/bin/bash
+# Copyright (C) 2025 Autocaliweb
+cd "$INSTALL_DIR"
+export PYTHONPATH="$INSTALL_DIR/scripts:$INSTALL_DIR"
+export CALIBRE_DBPATH="$CONFIG_DIR"
+source venv/bin/activate
+python cps.py
+EOF
+    
+    chmod +x "$INSTALL_DIR/start_autocaliweb.sh"
+    
+    print_status "Startup script created at $INSTALL_DIR/start_autocaliweb.sh"
+}
+
+# Main installation process
+main() {
+    print_status "Starting Autocaliweb manual installation..."
+    
+    check_dependencies
+    install_system_deps
+    check_directories
+    setup_autocaliweb
+    install_external_tools
+    setup_configuration
+    initialize_databases
+	retrieve_old_main_js
+    set_permissions
+    create_startup_script
+    create_systemd_service
+    
+    print_status "Installation completed successfully!"
+    echo
+    echo "=== Next Steps ==="
+    echo "1. Start the service: sudo systemctl start autocaliweb"
+    echo "2. Check status: sudo systemctl status autocaliweb"
+    echo "3. View logs: sudo journalctl -u autocaliweb -f"
+    echo "4. Access web interface: http://localhost:8083"
+    echo "5. Default login: admin/admin123"
+    echo
+    echo "=== Manual Start (Alternative) ==="
+    echo "Run: $INSTALL_DIR/start_autocaliweb.sh"
+    echo
+    echo "=== Configuration ==="
+    echo "- Main config: $CONFIG_DIR/app.db"
+    echo "- Directory config: $INSTALL_DIR/dirs.json"
+    echo "- Calibre library: $CALIBRE_LIB_DIR"
+    echo "- Book ingest: $INGEST_DIR"
+    echo
+    echo "=== Important Notes ==="
+    echo "- If you encounter hardcoded path errors, you may need to:"
+    echo "  1. Update scripts/acw_db.py schema_path to use $INSTALL_DIR"
+    echo "  2. Create missing directories manually"
+    echo "  3. Check file permissions if database errors occur"
+    echo
+    echo "=== Prerequisites ==="  
+    echo "- Ensure prep_autocaliweb.sh was run as root first"  
+    echo "- Autocaliweb source code should be in $INSTALL_DIR"
+}
+
+# Run main function
+main "$@"

--- a/scripts/prep_autocaliweb.sh
+++ b/scripts/prep_autocaliweb.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# prep_autocaliweb.sh - Run this as root first
+#
+# Copyright (C) 2025 Autocaliweb
+# First creator UsamaFoad <usamafoad@gmail.com>
+echo "=== Autocaliweb Directory Preparation Script ==="
+  
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then  
+   echo "This script must be run as root (use sudo)"
+   exit 1
+fi  
+  
+# Get the actual user who called sudo
+REAL_USER=${SUDO_USER:-$USER}
+REAL_UID=$(id -u "$REAL_USER")
+REAL_GID=$(id -g "$REAL_USER")
+
+echo "Creating directories for user: $REAL_USER ($REAL_UID:$REAL_GID)"
+  
+# Create main directories
+mkdir -p /app/autocaliweb
+mkdir -p /config
+mkdir -p /calibre-library
+mkdir -p /acw-book-ingest
+
+# Create config subdirectories (from acw-init service requirements)
+mkdir -p /config/processed_books/{converted,imported,failed,fixed_originals}
+mkdir -p /config/log_archive
+mkdir -p /config/.acw_conversion_tmp
+mkdir -p /config/.config/calibre/plugins
+  
+# Set ownership to the real user
+chown -R "$REAL_UID:$REAL_GID" /app/autocaliweb
+chown -R "$REAL_UID:$REAL_GID" /config
+chown -R "$REAL_UID:$REAL_GID" /calibre-library
+chown -R "$REAL_UID:$REAL_GID" /acw-book-ingest
+
+# Create symbolic link for calibre plugins
+ln -sf /config/.config/calibre/plugins /config/calibre_plugins
+  
+echo "Directory structure created successfully!"
+echo "Now run: ./install_autocaliweb.sh (as regular user)"


### PR DESCRIPTION
Hi, 

I started working on an issue for Autocaliweb source code. And since I don't have access to my PC right now and I don't want to install docker on my laptop, I consulted the documentation to see how to install the app manually without a docker. That is when I descovered that there is no such manual. Long story short, one thing led to another and I wite script to do that.  
The main issue is the hard-coded paths inside the source code. While it is great for Docker to find everything in its location, it is a problem for a manual installation. Instead of changing any of this pre-definded paths, I chose the easy workaround by creating two scripts. The first one (must run as root) create system folders similar to the docker ones (i.e., `/app/autocaliweb`, `/config`, ...etc). The second one install the app.  

* The first script (`prep_autocaliweb.sh`) create the following folders and set permission to the user how caled the sudo.


```
app
└── autocaliweb 

config
├── .acw_conversion_tmp
├── calibre_plugins -> /config/.config/calibre/plugins
├── .config
│   └── calibre
├── log_archive
└── processed_books
    ├── converted
    ├── failed
    ├── fixed_originals
    └── imported

calibre-library

acw-book-ingest
```

The second script (`install_autocaliweb.sh`) will run the following functions:

* check_dependencies
* install_system_deps
* check_directories
* setup_autocaliweb
* install_external_tools
* setup_configuration
* initialize_databases
* retrieve_old_main_js  (*temporary fix*)
* set_permissions
* create_startup_script
* create_systemd_service

Evry thing was good and run smothly until a cople days ago when Lina (@gelbphoenix) accepted Commit [1b3c75c](https://github.com/gelbphoenix/autocaliweb/commit/1b3c75c716310fda9375d00386b755c2b6ca2ec9). The scripts stil work fine and install the app. However, I encountering issues with the file chooser in Autocaliweb's admin interface, specifically when trying to set the "**Location of Calibre Database**". The logs indicate a 404 (NOT FOUND) error for the `/static/js/ajax/pathchooser/` endpoint, which is preventing the file browser from displaying directory contents.

The main issue is the changes in the `getPath()` function inside `cps/static/js/main.js`. 

**Old Version:**
```
# getPath() function Before 1b3c75c commit
function getPath() {
    var jsFileLocation = $("script[src*=jquery]").attr("src");  // the js file path
    return jsFileLocation.substr(0, jsFileLocation.search("/static/js/libs/jquery.min.js"));  // the js folder path
}
```

**New Version:**
```
# getPath() function After 1b3c75c commit
function getPath() {
    var jsFileLocation = $("script[src*=jquery]").attr("src"); // the js file path
    return jsFileLocation.substr(
        0,
        jsFileLocation.search("/libs/jquery.min.js")
    ); // the js folder path
}
```

If the web server is serving static files from `/static/`, and `jquery.min.js` is located at `/static/js/libs/jquery.min.js`, then:

* **Old getPath()**:  
**`jsFileLocation.search("/static/js/libs/jquery.min.js")`** would correctly find the index of **`/static/js/libs/jquery.min.js`**, and **substr** would return the base URL (e.g., **`http://192.168.1.8:8083`**).
* **New getPath()**:  
**`jsFileLocation.search("/libs/jquery.min.js")`** would find the index of **`/libs/jquery.min.js`** within **`/static/js/libs/jquery.min.js.`** This would result in **`getPath()`** returning **`http://192.168.1.8:8083/static/js`**, which is incorrect.  

When **`getPath()`** returns **`http://192.168.1.8:8083/static/js`**, then the AJAX request URL **`getPath() + request_path`** (e.g., **`http://192.168.1.8:8083/static/js + /ajax/pathchooser/`**) becomes **`http://192.168.1.8:8083/static/js/ajax/pathchooser/`**. This is precisely the 404 (NOT FOUND) URL I observed in my logs. The server expects the AJAX endpoint at **`http://192.168.1.8:8083/ajax/pathchooser/`**, not under **`/static/js/`**.  

This highlights a common problem in manual installation where subtle differences in file versions can lead to unexpected behavior, especially with hardcoded paths and client-side logic.  

I am not sure if adding manual installation is a good idea or not, I just like it and I believe giving the user more options is better for user experience. Anyway, if we decided to go with the manual installation I think this PR will be a good start point. Also, if someone asks why we don't have manual installation option that is why. 

### Where we stand right now?  

Unfortunately, we can't merge the current PR without solving the conflict with the `main.js` file. Either by revert to the previous version (*if that is possible option*), or by modfying it to retrive the old behaviour of the `getPath()` function. But that is not the main issue. I can solve the `main.js` problem by retiving the old version using `git` or `curl` during the manual installation (*I did that already*). Something like:

```
# Retriving old main.js using git or curl
git show dfd3a361af23bb5e7f1613f88cf3b19e0aee7c27:cps/static/js/main.js > /app/autocaliweb/cps/static/js/main.js

curl https://raw.githubusercontent.com/gelbphoenix/autocaliweb/dfd3a361af23bb5e7f1613f88cf3b19e0aee7c27/cps/static/js/main.js -o /app/autocaliweb/cps/static/js/main.js

```

My main point here is if we will agree about supporting the manual installation, we need to consider it and solve the hard-coded paths issue once and for all. Otherwise, many problem will arease with the manual install over and over.  
Maybe, we can isolate all the hard-coded paths in a setting file so that It became simpler to adjust for Docker or for manual installation based on the case.  
If you still reading until now I would like to thank you for your patience and hopefully I didn't wast your time.

*N.B. The current PR include the two script files (`prep_autocaliweb.sh` & `install_autocaliweb.sh`) in addition to edit in the `README.md` to point to the manual installtion. The step required for the installation itself I'll add it as a wiki page.*  


Best regards,