### PR TITLE
Clean content-type header in save_cover function

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -901,6 +901,9 @@ def save_cover_from_filestorage(filepath, saved_filename, img):
 # saves book cover to gdrive or locally
 def save_cover(img, book_path):
     content_type = img.headers.get('content-type')
+    # Clean content-type by removing charset and other parameters  
+    if content_type:  
+        content_type = content_type.split(';')[0].strip()  
 
     if use_IM:
         if content_type not in ('image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/bmp'):


### PR DESCRIPTION
> Removes charset and other parameters from the content-type header before validating image types in the `save_cover` function. This ensures proper content-type checking and prevents issues with additional header parameters.

Currently, I am working on creating a Deutsche Nationalbibliothek (DNB) metadata provider plugin. During this process, I encountered several bugs, some of which are related to Autocaliweb's core functionality rather than the plugin itself. I want to document three of these for future references.

**Issue No. 1: Book Title Space Collapse**

Book titles lose spaces when saving metadata, even without using "Fetch Metadata"

**Example:**  
* **Before saving**: "Das Parfum : die Geschichte eines Mörders"
* **After saving**: "DasParfum:dieGeschichteeinesMörders"
 
I added extensive logging and tracked this issue down to `editbooks.py:1448`, specifically after calling the `strip_whitespaces` function on the book title.

> INFO {editbooks.py:1448} handle_title_on_edit book title before strip_whitespaces: Das Parfum : die Geschichte eines Mörders 
> INFO {editbooks.py:1450} handle_title_on_edit book title AFTER strip_whitespaces: DasParfum:dieGeschichteeinesMörders
> 

This function uses `string_helper.py:21-22`, which employs a regular expression designed to remove *only* leading and trailing whitespace. However, in the application's context, it appeared to be removing *all* whitespace.

Interestingly, while the `strip_whitespaces` function works correctly in isolated Python tests (as shown below), its interaction within the larger application somehow leads to the removal of all whitespace. I didn't definitively pinpoint the culprit, but JavaScript interaction is suspected.

Thanks to @gelbphoenix, this problem is now fixed with commit #1e30419, which elegantly removes only leading and trailing whitespace without affecting internal spaces. For future reference, we need to consider this scenario: even if a Regex works well in isolated Python, there's no **guarantee** it will work correctly when interacting with other parts of the application (e.g., front-end frameworks, data serialization).

```
import re
def strip_whitespaces(text):
    return re.sub(r"(^[\s\u200B-\u200D\ufeff]+)|([\s\u200B-\u200D\ufeff]+$)","", text)
print(strip_whitespaces("Das Parfum : die Geschichte eines Mörders "))

# Output:
# Das Parfum : die Geschichte eines Mörders

```

**Issue No. 2: Cover Retrieval Failure (Silent)**  
I initially failed to retrieve any cover page from the DNB plugin. This led me to test other metadata provider plugins, and all exhibited the same behavior. Searching the Calibre-Web forum, I discovered this old post: [Fetch Metadata is extremely finicky](https://github.com/janeczku/calibre-web/issues/1889). 

To successfully retrieve a cover from a metadata provider, you need to:

1- **Enable Uploads**: Activate uploads in general via Admin -> Basic Configuration -> Feature Configuration -> Enable Uploads.
2- **Ensure User Permissions**: Confirm that the specific user also has upload permissions.

Otherwise, the cover retrieval process will fail silently, without showing any indication in the logs.

**Issue No. 3: Cover Image Content-Type Validation**

Retrieving cover photos from metadata providers to the book page was a good initial step, however, reliably saving these pictures presents a separate challenge.

Autocaliweb natively supports `image/jpeg` and `image/jpg` formats, and with ImageMagick available, it extends support to `image/png`, `image/bmp`, and `image/webp`. Despite this, saving a JPG file from certain metadata providers (including DNB) might still fail with an error: `Only jpg/jpeg/png/webp/bmp files are supported as coverfile`.

The reason for this unexpected behavior is that some providers return the cover image wrapped within **HTML content** (with an embedded `<img>` tag) or serve the image with an overly specific Content-Type header like `image/jpeg; charset=utf-8` instead of simply `image/jpeg`. This causes Autocaliweb's cover validation in `helper.py:895-900` to reject the file due to an unrecognized or overly complex content-type.

Extracting and cleaning this information within the metadata plugin itself before sending it to the book page will not solve the underlying problem. This is an architectural issue: the DNB provider validates the cover URL during the initial metadata search, but the actual cover download occurs later in a separate process when the user saves the book. At that point, Autocaliweb makes a fresh HTTP request to the service, which again returns the problematic Content-Type (e.g., `image/jpeg; charset=utf-8` or `text/html`), causing the saving operation to fail.

For this reason, the necessary header cleaning needs to occur directly within Autocaliweb's `helper.py:save_cover` function (around line 902). This PR implements that solution: it cleans the Content-Type header just before the validation check. This ensures that any 
service provider returning cover images with extraneous header information (or embedded in simple HTML) will now successfully pass the validation process, allowing covers to be saved correctly.

