### PR TITLE
Always recreate and start ACW services in install script

### DIFF
--- a/scripts/manual_install_acw.sh
+++ b/scripts/manual_install_acw.sh
@@ -529,7 +529,7 @@ download_and_extract_autocaliweb_source() {
         for item in "$INSTALL_DIR"/* "$INSTALL_DIR"/.*; do
         if [ -e "$item" ] && \
            [ "$item" != "$INSTALL_DIR/venv" ] && \
-           [ "$item" != "$INSTALL_DIR/scriptS" ] && \
+           [ "$item" != "$INSTALL_DIR/scripts" ] && \
            [[ ! "$item" =~ \.lock$ ]] && \
            [[ ! "$item" =~ \.db$ ]]; then
             rm -rf "$item"

--- a/scripts/manual_install_acw.sh
+++ b/scripts/manual_install_acw.sh
@@ -1474,25 +1474,18 @@ main() {
     initialize_databases
     set_permissions
 
-    # Only create services if they don't exist or if they've changed
-    if [ "$EXISTING_INSTALLATION" != true ]; then
-        create_systemd_service
-        create_acw_ingest_service
-        create_auto_zipper_service
-        create_metadata_change_detector
-    fi
+    # Always create the services
+    create_systemd_service
+    create_acw_ingest_service
+    create_auto_zipper_service
+    create_metadata_change_detector
 
     # Only run auto_library for new installations
     if [ "$install_SCENARIO" != "with_template" ] && [ "$EXISTING_INSTALLATION" != true ]; then
         run_auto_library
     fi
 
-    # Use appropriate service start method
-    if [ "$EXISTING_INSTALLATION" = true ]; then
-        restart_acw_services
-    else
-        start_acw_services
-    fi
+    start_acw_services
 
     set_acw_permissions
     verify_installation


### PR DESCRIPTION
**Always recreate and start ACW systemd services on install/update.**

This PR modifies `manual_install_acw.sh` to ensure all Autocaliweb-related systemd service files are always created and started, regardless of whether it's a fresh installation or an update.

Previously, the installer made minimal changes during updates, which could lead to a partial installation if service files were deleted or corrupted. This change guarantees that services are always up-to-date and available after the installation process completes, simplifying overall service management.
Fix #47 

