### PR TITLE
Add multi-email selection for eReader sending

### DIFF
--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -12059,3 +12059,18 @@ body.edituser .modal-content {
     display: none;
   }
 }
+/* Email Selection Modal Positioning */
+#emailSelectModal {
+    position: fixed;
+    top: 70px; /* Adjusted based on navbar height */
+    left:calc(50% + 20px); /* Adding 20px looks better*/
+    transform: translateX(-50%);
+    z-index: 1050;
+    margin: 0;
+}
+
+#emailSelectModal .modal-dialog {
+    margin: 0;
+    width: 90%;
+    max-width: 600px;
+}

--- a/cps/static/js/email_selection.js
+++ b/cps/static/js/email_selection.js
@@ -1,0 +1,79 @@
+/**
+ * Email Selection functionality for selective eReader sending
+ * Handles both modal and redirect scenarios
+ */
+
+$(document).ready(function() {
+    // Handle the Send to eReader button click
+    $(document).on('click', '#sendToEReaderBtn', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var bookId = $(this).data('book-id');
+
+        // Check if we're in the floating modal context
+        var isInFloatingModal = $('#bookDetailsModal').length > 0 &&
+                               ($('#bookDetailsModal').hasClass('in') || $('#bookDetailsModal').is(':visible'));
+
+        if (isInFloatingModal) {
+            // Redirect to full page
+            window.location.href = '/book/' + bookId;
+        } else {
+            // Show the email selection modal
+            $('#emailSelectModal').modal('show');
+        }
+    });
+
+    // Handle send button click in email selection modal
+    $('#sendSelectedBtn').click(function() {
+        var selectedEmails = [];
+        $('input[name="selected_emails"]:checked').each(function() {
+            selectedEmails.push($(this).val());
+        });
+
+        if (selectedEmails.length === 0) {
+            alert($('#emailSelectModal').data('no-email-message') || 'Please select at least one email address');
+            return;
+        }
+
+        var formatSelect = $('select[name="format_selection"]');
+        var selectedFormat = formatSelect.val();
+        var convertFlag = formatSelect.find(':selected').data('convert');
+        var bookId = $('#emailSelectModal').data('book-id');
+
+        // Send AJAX request to endpoint
+        $.ajax({
+            url: '/send_selected/' + bookId,
+            method: 'POST',
+            data: {
+                'csrf_token': $('input[name="csrf_token"]').val(),
+                'selected_emails': selectedEmails.join(','),
+                'book_format': selectedFormat,
+                'convert': convertFlag
+            },
+            success: function(response) {
+                $('#emailSelectModal').modal('hide');
+                if (response.length > 0 && response[0].type === 'success') {
+                    alert(response[0].message);
+                } else if (response.length > 0) {
+                    alert(response[0].message);
+                }
+            },
+            error: function() {
+                alert($('#emailSelectModal').data('error-message') || 'Error sending email');
+            }
+        });
+    });
+
+    // Handle select all/none functionality
+    $('#selectAllEmails').change(function() {
+        $('input[name="selected_emails"]').prop('checked', this.checked);
+    });
+
+    // Update select all checkbox when individual checkboxes change
+    $('input[name="selected_emails"]').change(function() {
+        var totalCheckboxes = $('input[name="selected_emails"]').length;
+        var checkedCheckboxes = $('input[name="selected_emails"]:checked').length;
+        $('#selectAllEmails').prop('checked', totalCheckboxes === checkedCheckboxes);
+    });
+});

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -52,29 +52,68 @@
                             </div>
                         {% endif %}
                         {% if current_user.kindle_mail and entry.email_share_list %}
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            {% if entry.email_share_list.__len__() == 1 %}
-                                <div class="btn-group" role="group">
-                                    <button id="sendbtn" class="btn btn-primary sendbtn-form" data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=entry.email_share_list[0]['format'], convert=entry.email_share_list[0]['convert'])}}">
-                                        <span class="glyphicon glyphicon-send"></span> {{entry.email_share_list[0]['text']}}
-                                    </button>
-                                </div>
-                            {% else %}
-                                <div class="btn-group" role="group">
-                                    <button id="sendbtn2" type="button" class="btn btn-primary dropdown-toggle"
-                                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                        <span class="glyphicon glyphicon-send"></span>{{ _('Send to eReader') }}
-                                        <span class="caret"></span>
-                                    </button>
-                                    <ul class="dropdown-menu" aria-labelledby="send-to-ereader">
-                                        {% for format in entry.email_share_list %}
-                                            <li>
-                                                <a class="sendbtn-form" data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=format['format'], convert=format['convert'])}}">{{ format['text'] }}</a>
-                                            </li>
+                            <div class="btn-group" role="group">
+                                <button type="button" class="btn btn-primary" id="sendToEReaderBtn" data-book-id="{{ entry.id }}">
+                                    <span class="glyphicon glyphicon-send"></span> {{ _('Send to eReader') }}
+                                </button>
+                            </div>
+
+                            <!-- Email Selection Modal -->
+                            <div class="modal fade" id="emailSelectModal" tabindex="-1" role="dialog"
+                                 data-book-id="{{ entry.id }}"
+                                 data-no-email-message="{{ _('Please select at least one email address') }}"
+                                 data-error-message="{{ _('Error sending email') }}">
+                                <div class="modal-dialog" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <button type="button" class="close" data-dismiss="modal">
+                                                <span>&times;</span>
+                                            </button>
+                                            <h4 class="modal-title">{{ _('Select eReader Email Addresses') }}</h4>
+                                        </div>
+                                        <div class="modal-body">
+                            <form id="emailSelectForm">
+                                <div class="form-group">
+                                    <fieldset>
+                                        <legend>{{ _('Choose email addresses:') }}</legend>
+                                        <div class="checkbox">
+                                            <label for="selectAllEmails">
+                                                <input type="checkbox" id="selectAllEmails" checked>
+                                                <strong>{{ _('Select All') }}</strong>
+                                            </label>
+                                        </div>
+                                        <hr>
+                                        {% for email in current_user.kindle_mail.split(',') %}
+                                            <div class="checkbox">
+                                                <label for="email-{{ loop.index }}">
+                                                    <input type="checkbox" id="email-{{ loop.index }}" name="selected_emails" value="{{ email.strip() }}" checked>
+                                                    {{ email.strip() }}
+                                                </label>
+                                            </div>
                                         {% endfor %}
-                                    </ul>
+                                    </fieldset>
                                 </div>
-                            {% endif %}
+
+                                <div class="form-group">
+                                    <label for="format_selection">{{ _('Select format:') }}</label>
+                                    <select id="format_selection" name="format_selection" class="form-control">
+                                        {% for format in entry.email_share_list %}
+                                            <option value="{{ format['format'] }}" data-convert="{{ format['convert'] }}">
+                                                {{ format['text'] }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </form>
+                        </div>
+
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-default" data-dismiss="modal">{{ _('Cancel') }}</button>
+                                            <button type="button" class="btn btn-primary" id="sendSelectedBtn">{{ _('Send') }}</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         {% endif %}
                     {% endif %}
                     {% if entry.reader_list and current_user.role_viewer() %}
@@ -109,13 +148,6 @@
                                     <span class="caret"></span>
                                 </button>
                                 <ul class="dropdown-menu" aria-labelledby="listen-in-browser">
-                                    {% for format in entry.reader_list %}
-                                        <li><a target="_blank" href="{{ url_for('web.read_book', book_id=entry.id, book_format=format) }}">{{ format }}</a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                                <ul class="dropdown-menu" aria-labelledby="listen-in-browser">
-
                                     {% for format in entry.data %}
                                         {% if format.format|lower in entry.audio_entries %}
                                             <li><a target="_blank"
@@ -197,9 +229,9 @@
             {% if entry.publishers|length > 0 %}
                 <div class="publishers">
                     <p>
-				      <span>{{ _('Publisher') }}:
-				          <a href="{{ url_for('web.books_list', data='publisher', sort_param='stored', book_id=entry.publishers[0].id ) }}">{{ entry.publishers[0].name }}</a>
-				      </span>
+                      <span>{{ _('Publisher') }}:
+                          <a href="{{ url_for('web.books_list', data='publisher', sort_param='stored', book_id=entry.publishers[0].id ) }}">{{ entry.publishers[0].name }}</a>
+                      </span>
                     </p>
                 </div>
             {% endif %}
@@ -327,9 +359,9 @@
                                                class="btn btn-sm btn-default" role="button"
                                                data-shelf-action="remove"
                                             >
-								              <span {% if not shelf.is_public or current_user.role_edit_shelfs() %}
-								                  class="glyphicon glyphicon-remove"
-								              {% endif %}></span> {{ shelf.name }}{% if shelf.is_public == 1 %} {{ _('(Public)') }}{% endif %}
+                                              <span {% if not shelf.is_public or current_user.role_edit_shelfs() %}
+                                                  class="glyphicon glyphicon-remove"
+                                              {% endif %}></span> {{ shelf.name }}{% if shelf.is_public == 1 %} {{ _('(Public)') }}{% endif %}
                                             </a>
                                         {% endif %}
                                     {% endfor %}
@@ -371,6 +403,7 @@
 </script>
 <script src="{{ url_for('static', filename='js/details.js') }}"></script>
 <script src="{{ url_for('static', filename='js/fullscreen.js') }}"></script>
+<script src="{{ url_for('static', filename='js/email_selection.js') }}"></script>
 <script type="text/javascript">
 </script>
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -1356,6 +1356,32 @@ def send_to_ereader(book_id, book_format, convert):
         response = [{'type': "danger", 'message': _("Oops! Please update your profile with a valid eReader Email.")}]
     return Response(json.dumps(response), mimetype='application/json')
 
+@web.route('/send_selected/<int:book_id>', methods=["POST"])
+@login_required_if_no_ano
+@download_required
+def send_to_selected_ereaders(book_id):
+    if not config.get_mail_server_configured():
+        response = [{'type': "danger", 'message': _("Please configure the SMTP mail settings first...")}]
+        return Response(json.dumps(response), mimetype='application/json')
+
+    selected_emails = request.form.get('selected_emails', '')
+    book_format = request.form.get('book_format', '')
+    convert = request.form.get('convert', '0')
+
+    if not selected_emails:
+        response = [{'type': "danger", 'message': _("No email addresses selected")}]
+        return Response(json.dumps(response), mimetype='application/json')
+
+    result = send_mail(book_id, book_format, int(convert), selected_emails, config.get_book_path(),
+                       current_user.name)
+
+    if result is None:
+        ub.update_download(book_id, int(current_user.id))
+        response = [{'type': "success", 'message': _("Success! Book queued for sending to selected addresses")}]
+    else:
+        response = [{'type': "danger", 'message': _("Oops! There was an error sending book: %(res)s", res=result)}]
+
+    return Response(json.dumps(response), mimetype='application/json')
 
 # ################################### Login Logout ##################################################################
 


### PR DESCRIPTION
* Introduces a modal for selecting multiple eReader email addresses and book format before sending. 
* Adds supporting JavaScript for modal logic and AJAX submission, updates the detail page to use the new modal, and implements a new backend endpoint to handle sending to multiple selected addresses. 
* Fix: #51

The modal work ok with the new theme scince the book open in static page (book/{id}). I failed to make the modal over the navigation bar so I just moved it down :) the CSS in `caliBlur.css` file may need a lettle fine tone.

[Modal Documentation](https://getbootstrap.com/docs/4.0/components/modal/)
```
Bootstrap only supports one modal window at a time. Nested modals aren’t supported as we believe them to be poor user experiences.
```
**Regarded the old theme**: I discovered the hard way that nested modal is a bad idea. Since the default Book Details page open in Modal and nested modals are not supported. I made the "*Send to eReader*" button forward to the static page ( book/{id}) then another click will shows the "**Select eReader Email Addresses**" form. It is not great workaround but it works.
Currently, the supported formats from Atuocaliweb are PDF, EPUB, and AZW. We may consider if any other format needed (ex. AZW3).