### PR TITLE
Update ingest_processor.py - NameError: name 'self' is not defined

### DIFF
--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -93,6 +93,7 @@ class NewBookProcessor:
             con.close()
             return None
         
+    @staticmethod
     def wait_for_file_stable(filepath, stable_seconds=5, timeout=120):
         """Waits for a file to become stable, meaning it hasn't changed in size for a certain period of time."""
         last_size = -1
@@ -349,7 +350,7 @@ def main(filepath=sys.argv[1]):
         return
     
     try:
-        self.wait_for_file_stable(filepath)
+        NewBookProcessor.wait_for_file_stable(filepath)
     except TimeoutError as e:
         print(f"[ingest-processor] Skipping {filepath} due to timeout error: {e}", flush=True)
         return


### PR DESCRIPTION
When manually refreshing the library via the WebUI and while having a book inside the /acw-book-ingest folder, In my setup /acw-book-ingest is mapped to a remote folder in my NAS.

An error message displayed in the logs is as follows:

``` code
Traceback (most recent call last):
  File "/app/autocaliweb/scripts/ingest_processor.py", line 397, in <module>
    main()
  File "/app/autocaliweb/scripts/ingest_processor.py", line 349, in main
    main(f)
  File "/app/autocaliweb/scripts/ingest_processor.py", line 349, in main
    main(f)
  File "/app/autocaliweb/scripts/ingest_processor.py", line 349, in main
    main(f)
  [Previous line repeated 1 more time]
  File "/app/autocaliweb/scripts/ingest_processor.py", line 353, in main
    self.wait_for_file_stable(filepath)
NameError: name 'self' is not defined
```

In the main() section there is a "try" section that calls "self.wait_for_file_stable(filepath)" and is here where "self" is not defined as that function is part of the "NewBookProcessor Class"

``` python
    if os.path.isdir(filepath) and Path(filepath).exists():
        # print(os.listdir(filepath))
        for filename in os.listdir(filepath):
            f = os.path.join(filepath, filename)
            if Path(f).exists():
                main(f)
        return
    
    try:
        self.wait_for_file_stable(filepath)
    except TimeoutError as e:
        print(f"[ingest-processor] Skipping {filepath} due to timeout error: {e}", flush=True)
        return

    nbp = NewBookProcessor(filepath)
```

With the decorator @staticmethod and calling the function by: "NewBookProcessor.wait_for_file_stable(filepath)" I can now import books stored in the /acw-book-ingest folder and all is working.

I just can't get it to do Auto Import, I place an ebook in the same folder (acw-book-ingest) wait 5 minutes and nothing I have to manually refresh library to get the book to "Import".
