### PR TITLE
Comment out legacy calibre_db.dispose() in shutdown function

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -145,7 +145,7 @@ def shutdown():
     show_text = {}
     if task in (0, 1):  # valid commandos received
         # close all database connections
-        calibre_db.dispose()
+        # calibre_db.dispose()
         ub.dispose()
 
         if task == 0:


### PR DESCRIPTION
The call to `calibre_db.dispose()` has been commented out in the shutdown function, since the `teardown()` method in `cps/db.py:651-654` already handles cleanup. Fix: #64