### PR TITLE
Update detail.html - add tooltip to Send to eReader button

### DIFF
--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -53,7 +53,7 @@
                         {% endif %}
                         {% if current_user.kindle_mail and entry.email_share_list %}
                             <div class="btn-group" role="group">
-                                <button id="sendToEReaderBtn" type="button" class="btn btn-primary" data-book-id="{{ entry.id }}">
+                                <button id="sendToEReaderBtn" type="button" class="btn btn-primary" data-book-id="{{ entry.id }}" data-toggle="tooltip" title="{{ _('Send to eReader') }}" data-placement="bottom" data-viewport=".btn-toolbar">
                                     <span class="glyphicon glyphicon-send"></span> {{ _('Send to eReader') }}
                                 </button>
                             </div>


### PR DESCRIPTION
- Add the missing tooltip to the `Send to eReader` button.
- 
![Screenshot 2025-08-15 163315](https://github.com/user-attachments/assets/91101f41-a08b-44c3-988e-735850edf7de)
