### PR TITLE
Update hardcover.py

### DIFF
--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -117,6 +117,10 @@ class HardcoverClient:
             # Book doesn't exist, add it in Reading status
             if not book: 
                 book = self.add_book(ids, status=2)
+            # Edge case: if book doesn't exist and add_book failed to add it
+            if book is None:
+                print(f"Warning: Could not find book with identifiers {ids} for progress update. Skipping.")
+            return # Exit early if the book object is None
             # Book is either WTR or Read, and we aren't finished reading
             if book.get("status_id") != 2 and progress_percent != 100: 
                 book = self.change_book_status(book, 2)


### PR DESCRIPTION
**Handle edge case**: when a user has Hardcover sync enabled but the book they're reading on their Kobo device doesn't exist in their Hardcover library and can't be automatically added (perhaps due to missing identifiers or API issues). Check if `book` is `None` before calling `book.get("status_id")` Fix: #71