### PR TITLE
Fix issues in the ingest processor

### DIFF
--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -124,7 +124,7 @@ class NewBookProcessor:
         self.acw_settings = self.db.acw_settings
         USER_NAME = os.environ.get("ACW_USER", "abc")
         GROUP_NAME = os.environ.get("ACW_GROUP", "abc")
-        owner_group_string = f"{USER_NAME}:{GROUP_NAME}"
+        self.owner_group_string = f"{USER_NAME}:{GROUP_NAME}"
 
         self.auto_convert_on = self.acw_settings['auto_convert']
         self.target_format = self.acw_settings['auto_convert_target_format']
@@ -502,7 +502,7 @@ class NewBookProcessor:
 
     def set_library_permissions(self):
         try:
-            subprocess.run(["chown", "-R", owner_group_string, self.library_dir], check=True)
+            subprocess.run(["chown", "-R", self.owner_group_string, self.library_dir], check=True)
         except subprocess.CalledProcessError as e:
             print(f"[ingest-processor] An error occurred while attempting to recursively set ownership of {self.library_dir} to owner_group_string. See the following error:\n{e}", flush=True)
 


### PR DESCRIPTION
1. Existing ingest script breaks while trying to set permissions due to the unbound `owner_group_string` variable.
2. There is also seems to be an issue with the wrong variable name in `fetch_metadata_if_enabled` and `trigger_auto_send_if_enabled`

Fix: https://github.com/gelbphoenix/autocaliweb/issues/83

```
CALIBREDB EXIT/ERROR CODE: 1
None
Traceback (most recent call last):
  File "/app/autocaliweb/scripts/ingest_processor.py", line 417, in <module>
    main()
  File "/app/autocaliweb/scripts/ingest_processor.py", line 369, in main
    main(f)
  File "/app/autocaliweb/scripts/ingest_processor.py", line 369, in main
    main(f)
  File "/app/autocaliweb/scripts/ingest_processor.py", line 412, in main
    nbp.set_library_permissions()
  File "/app/autocaliweb/scripts/ingest_processor.py", line 344, in set_library_permissions
    subprocess.run(["chown", "-R", owner_group_string, self.library_dir], check=True)
NameError: name 'owner_group_string' is not defined
[library-refresh] An unexpected error occurred, check the logs ⛔
```