### PR TITLE
Update litres.py add r (raw) to the second string at line 261

### DIFF
--- a/cps/metadata_provider/litres.py
+++ b/cps/metadata_provider/litres.py
@@ -258,7 +258,7 @@ class Litres(Metadata):
         ).strip()
 
         formats = ['pdf', 'epub']
-        pattern = r'\s*\([^)]*(' + '|'.join(formats) + ')[^)]*\)'
+        pattern = r'\s*\([^)]*(' + '|'.join(formats) + r')[^)]*\)'
 
         title =  re.sub(pattern, '', title, flags=re.IGNORECASE)
         return title


### PR DESCRIPTION
- **Fix: SyntaxWarning: invalid escape sequence '\)'**
- It's only a SyntaxWarning and not a hard error. However, this warning can actually become a full-fledged SyntaxError in newer versions of Python, so addressing it now prevents future issues.
- The first part of the string at line 261 was made "raw", while the seond was not. 
- The fix: Make the second part (_the one that handles backslash before the closing parenthesis_) raw too (add r before it).
```
 [2025-09-16 09:02:03,551]  WARN {warnings.py:110} /app/autocaliweb/cps/metadata_provider/litres.py:261: SyntaxWarning: invalid escape sequence '\)'

  pattern = r'\s*\([^)]*(' + '|'.join(formats) + ')[^)]*\)'
```

**Suggested code **: ```pattern = r'\s*\([^)]*(' + '|'.join(formats) + r')[^)]*\)'``` That will prevent treating `\)` as escape sequence, exactly as the first one `\(`.