### PR TITLE
Update dockerhub-build-push-on-push.yml

### DIFF
--- a/.github/workflows/dockerhub-build-push-on-push.yml
+++ b/.github/workflows/dockerhub-build-push-on-push.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       IMAGE_TAG: placeholder
       LOWER_REPO_NAME: placeholder
+      LOWER_REPO_OWNER: placeholder
 
     steps:
       - name: Checkout correct branch
@@ -32,8 +33,10 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Set repo name to lowercase
-        run: echo "LOWER_REPO_NAME=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Set repo and owner names to lowercase
+        run: |
+          echo "LOWER_REPO_NAME=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "LOWER_REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Determine Docker Image Tag
         id: tag
@@ -50,7 +53,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
+          
       - name: GitHub Container Registry Login
         uses: docker/login-action@v3
         with:
@@ -76,7 +79,7 @@ jobs:
             VERSION=${{ vars.CURRENT_DEV_VERSION }}-DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/autocaliweb:${{ env.IMAGE_TAG }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ env.LOWER_REPO_OWNER }}/${{ env.LOWER_REPO_NAME }}:${{ env.IMAGE_TAG }}
           platforms: linux/amd64,linux/arm64
 
       - name: Increment dev build number


### PR DESCRIPTION
**Enforce lowercase conversion for repository owner names**

Currently, only the repository name is converted to lowercase before use. This update ensures that the repository owner's name is also converted to lowercase.

This prevents potential build failures and dependency resolution issues in case-sensitive environments where a user's repository URL or username contains uppercase characters (*e.g., MySelf*). The change ensures consistent, case-agnostic reference to the repository.

Summary of Changes:

- Set both repository name and owner names to lowercase for reliable lookups.
